### PR TITLE
Reuse thread IDs and refine image handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Local Netlify folder
 .netlify
+
+# Dependencies
+node_modules/
+
+# OS files
+.DS_Store

--- a/tests/isImageRequest.test.js
+++ b/tests/isImageRequest.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { isImageRequest } = require('../functions/assistant');
+
+assert.strictEqual(isImageRequest('draw a cat'), true, 'direct image prompt');
+assert.strictEqual(isImageRequest('Make it blue', 'draw a cat'), true, 'edit with reference to previous prompt');
+assert.strictEqual(isImageRequest('How are you?'), false, 'non-image prompt');
+assert.strictEqual(isImageRequest('Make the phone a little smaller', 'draw a phone'), true, 'edit without image keyword');
+
+console.log('All isImageRequest tests passed.');


### PR DESCRIPTION
## Summary
- Ensure existing `threadId` is reused instead of always creating a new thread
- Replace non-ASCII bullet in DALL-E references and search all response files for images
- Broaden image edit detection and add unit tests for `isImageRequest`

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac6213e5a8832d920b209b07055ba4