### PR TITLE
Reuse thread IDs and refine image handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Local Netlify folder
 .netlify
+
+# Dependencies
+node_modules/
+
+# OS files
+.DS_Store

--- a/functions/assistant.js
+++ b/functions/assistant.js
@@ -2,9 +2,11 @@ const fetch = require('node-fetch');
 
 function isImageRequest(prompt, previousPrompt) {
     const directImagePrompt = /draw|illustrate|image|picture|generate.*image|create.*image/i.test(prompt);
-    const editRequest = /(make|change|remove|replace|update|edit).*image/i.test(prompt);
-    return directImagePrompt || (previousPrompt && editRequest);
+    const editRequest = /(make|change|remove|replace|update|edit)(.*image|.*it|)/i.test(prompt);
+    return directImagePrompt || (!!previousPrompt && editRequest);
 }
+
+exports.isImageRequest = isImageRequest;
 
 function enhancePrompt(prompt) {
     return `In a cute, cartoon, craft-friendly style: ${prompt}`;
@@ -47,7 +49,10 @@ exports.handler = async (event) => {
                 .filter(msg => msg.role === "user" && Array.isArray(msg.content))
                 .sort((a, b) => b.created_at - a.created_at);
 
-            previousPrompt = userMsgs[1]?.content?.[0]?.text?.value || null;
+            const lastUserMsg = userMsgs[0];
+            if (lastUserMsg?.content?.[0]?.text?.value) {
+                previousPrompt = lastUserMsg.content[0].text.value;
+            }
         }
 
         if (!userMessage) {
@@ -67,18 +72,23 @@ exports.handler = async (event) => {
             };
         }
 
-        const threadRes = await fetch("https://api.openai.com/v1/threads", {
-            method: "POST",
-            headers: {
-                "Authorization": `Bearer ${OPENAI_KEY}`,
-                "Content-Type": "application/json",
-                "OpenAI-Beta": "assistants=v2"
-            }
-        }).then(res => res.json());
+        let thread_id = threadId;
+        if (!thread_id) {
+            const threadRes = await fetch("https://api.openai.com/v1/threads", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${OPENAI_KEY}`,
+                    "Content-Type": "application/json",
+                    "OpenAI-Beta": "assistants=v2"
+                }
+            }).then(res => res.json());
 
-        console.log("THREAD RESPONSE:", threadRes);
+            console.log("THREAD RESPONSE:", threadRes);
 
-        const thread_id = threadRes.id;
+            thread_id = threadRes.id;
+        } else {
+            console.log("Reusing thread:", thread_id);
+        }
 
         await fetch(`https://api.openai.com/v1/threads/${thread_id}/messages`, {
             method: "POST",
@@ -168,14 +178,17 @@ exports.handler = async (event) => {
             image: null
         };
 
-        // Attempt to find image file in content or files
+        // Attempt to find image file in content or any of the response files
         let imagePart = contentArray.find(c => c.type === "image_file") || null;
         if (!imagePart && Array.isArray(lastMsg.files) && lastMsg.files.length > 0) {
-            imagePart = {
-                image_file: {
-                    file_id: lastMsg.files[0].id
-                }
-            };
+            const imageFile = lastMsg.files.find(f => (f?.content_type || "").startsWith("image/"));
+            if (imageFile) {
+                imagePart = {
+                    image_file: {
+                        file_id: imageFile.id
+                    }
+                };
+            }
         }
 
         if (imagePart?.image_file?.file_id) {
@@ -193,7 +206,7 @@ exports.handler = async (event) => {
 
         let imageUrl = assistantResponse.image;
 
-        // Fallback: if no image from assistant and user message indicates image request, generate image via DALL·E 3
+        // Fallback: if no image from assistant and user message indicates image request, generate image via DALL-E 3
         if (!imageUrl && isImageRequest(userMessage, previousPrompt)) {
             try {
                 const editing = previousPrompt && /(make|change|remove|replace|update|edit)/i.test(userMessage);
@@ -218,7 +231,7 @@ exports.handler = async (event) => {
                 if (!imageRes.ok) {
                     const errText = await imageRes.text();
                     console.error("Image API error response:", errText);
-                    throw new Error("DALL·E image generation failed.");
+                    throw new Error("DALL-E image generation failed.");
                 }
 
                 let imageData;

--- a/tests/isImageRequest.test.js
+++ b/tests/isImageRequest.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { isImageRequest } = require('../functions/assistant');
+
+assert.strictEqual(isImageRequest('draw a cat'), true, 'direct image prompt');
+assert.strictEqual(isImageRequest('Make it blue', 'draw a cat'), true, 'edit with reference to previous prompt');
+assert.strictEqual(isImageRequest('How are you?'), false, 'non-image prompt');
+assert.strictEqual(isImageRequest('Make the phone a little smaller', 'draw a phone'), true, 'edit without image keyword');
+
+console.log('All isImageRequest tests passed.');


### PR DESCRIPTION
## Summary
- Ensure existing `threadId` is reused instead of always creating a new thread
- Replace non-ASCII bullet in DALL-E references and search all response files for images
- Broaden image edit detection and add unit tests for `isImageRequest`
- Correctly capture the latest user prompt to enable image edits on follow-up messages

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac6213e5a8832d920b209b07055ba4