### PR TITLE
Handle non-JSON responses in assistant fetch

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,14 @@ async function sendMessage() {
             body: JSON.stringify({ message, threadId: getOrCreateThreadId(), lastImagePrompt, lastImageUrl })
         });
 
-        const data = await response.json();
+        const text = await response.text();
+        let data;
+        try {
+            data = JSON.parse(text);
+        } catch {
+            console.warn('Non-JSON response:', text);
+            data = { error: text };
+        }
 
         if (!response.ok || data.error) {
             throw new Error(data.error || `HTTP ${response.status}`);


### PR DESCRIPTION
## Summary
- Parse assistant responses from text and handle non-JSON payloads
- Log non-JSON responses for debugging
- Surface server or network errors to the UI

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca83b4fd8832da2e8ba4196fbe6fb