### PR TITLE
Handle non-JSON responses in assistant fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <footer>
             <div class="input-wrapper">
                 <span class="upload-btn">📎</span>
+                <input type="file" id="file-input" style="display: none;">
                 <input type="text" id="user-input" placeholder="Type your message...">
                 <button id="send-btn">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="white">

--- a/script.js
+++ b/script.js
@@ -21,16 +21,50 @@ function isImagePrompt(msg) {
     return imageKeywords.some(kw => msg.toLowerCase().includes(kw));
 }
 
+function readFileAsBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result.split(',')[1];
+            resolve(result);
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
 async function sendMessage() {
     const input = document.getElementById('user-input');
+    const fileInput = document.getElementById('file-input');
     const message = input.value.trim();
-    if (!message) return;
+    const file = fileInput.files[0];
+    if (!message && !file) return;
 
     const messagesDiv = document.getElementById('messages');
-    const userMsg = document.createElement('div');
-    userMsg.textContent = message;
-    userMsg.className = 'message user';
-    messagesDiv.appendChild(userMsg);
+
+    if (file) {
+        if (file.type.startsWith('image/')) {
+            const img = document.createElement('img');
+            img.src = URL.createObjectURL(file);
+            img.alt = file.name;
+            img.style.maxWidth = '300px';
+            img.className = 'message user';
+            messagesDiv.appendChild(img);
+        } else {
+            const fileMsg = document.createElement('div');
+            fileMsg.textContent = `📎 ${file.name}`;
+            fileMsg.className = 'message user';
+            messagesDiv.appendChild(fileMsg);
+        }
+    }
+
+    if (message) {
+        const userMsg = document.createElement('div');
+        userMsg.textContent = message;
+        userMsg.className = 'message user';
+        messagesDiv.appendChild(userMsg);
+    }
+
     input.value = "";
 
     // Show loading animation
@@ -40,13 +74,42 @@ async function sendMessage() {
     messagesDiv.appendChild(loadingMsg);
 
     try {
+        let attachment = null;
+        let attachmentName = null;
+        let attachmentType = null;
+        if (file) {
+            attachment = await readFileAsBase64(file);
+            attachmentName = file.name;
+            attachmentType = file.type;
+        }
+
+        const payload = {
+            message,
+            threadId: getOrCreateThreadId(),
+            lastImagePrompt,
+            lastImageUrl
+        };
+
+        if (attachment) {
+            payload.attachment = attachment;
+            payload.attachmentName = attachmentName;
+            payload.attachmentType = attachmentType;
+        }
+
         const response = await fetch('/.netlify/functions/assistant', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ message, threadId: getOrCreateThreadId(), lastImagePrompt, lastImageUrl })
+            body: JSON.stringify(payload)
         });
 
-        const data = await response.json();
+        const text = await response.text();
+        let data;
+        try {
+            data = JSON.parse(text);
+        } catch {
+            console.warn('Non-JSON response:', text);
+            data = { error: text };
+        }
 
         if (!response.ok || data.error) {
             throw new Error(data.error || `HTTP ${response.status}`);
@@ -81,6 +144,7 @@ async function sendMessage() {
         }
 
         loadingMsg.remove();
+        fileInput.value = "";
     } catch (err) {
         loadingMsg.remove();
         const errorMsg = document.createElement('div');
@@ -94,6 +158,8 @@ async function sendMessage() {
 document.addEventListener("DOMContentLoaded", () => {
     const input = document.getElementById("user-input");
     const sendBtn = document.getElementById("send-btn");
+    const uploadBtn = document.querySelector(".upload-btn");
+    const fileInput = document.getElementById("file-input");
 
     input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") {
@@ -103,4 +169,5 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     sendBtn.addEventListener("click", sendMessage);
+    uploadBtn.addEventListener("click", () => fileInput.click());
 });


### PR DESCRIPTION
## Summary
- Parse assistant responses from text and handle non-JSON payloads
- Log non-JSON responses for debugging
- Surface server or network errors to the UI
- Allow uploading attachments from the chat interface and forward files to the assistant

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca83b4fd8832da2e8ba4196fbe6fb