### PR TITLE
Handle non-JSON responses in assistant fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
         <footer>
             <div class="input-wrapper">
                 <span class="upload-btn">📎</span>
+                <input type="file" id="file-input" style="display: none;">
+                <span id="file-indicator" class="file-indicator"></span>
                 <input type="text" id="user-input" placeholder="Type your message...">
                 <button id="send-btn">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="white">

--- a/style.css
+++ b/style.css
@@ -54,6 +54,11 @@ input[type="text"] {
   user-select: none;
 }
 
+.file-indicator {
+  font-size: 14px;
+  color: #555;
+}
+
 #send-btn {
   background-color: #c55982;
   border: none;


### PR DESCRIPTION
## Summary
- Parse assistant responses from text and handle non-JSON payloads
- Log non-JSON responses for debugging
- Surface server or network errors to the UI
- Allow uploading attachments from the chat interface and forward files to the assistant
- Show a small "file selected" indicator after picking an attachment and clear it after sending

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aca83b4fd8832da2e8ba4196fbe6fb