### PR TITLE
Clear file preview and indicator on removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
                 <label for="file-input" class="upload-btn" id="upload-btn">📎</label>
                 <input type="file" id="file-input" style="display: none;">
                 <span id="file-indicator" class="file-indicator"></span>
+                <img id="file-preview" class="file-preview" alt="Preview" />
+                <span id="remove-file" class="remove-icon">✖</span>
                 <input type="text" id="user-input" placeholder="Type your message...">
                 <button id="send-btn">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="white">

--- a/script.js
+++ b/script.js
@@ -36,6 +36,8 @@ function readFileAsBase64(file) {
 async function sendMessage() {
     const input = document.getElementById('user-input');
     const fileInput = document.getElementById('file-input');
+    const filePreview = document.getElementById('file-preview');
+    const removeIcon = document.getElementById('remove-file');
     const message = input.value.trim();
     const file = fileInput.files[0];
     if (!message && !file) return;
@@ -147,6 +149,13 @@ async function sendMessage() {
           fileInput.value = "";
           const fileIndicator = document.getElementById('file-indicator');
           if (fileIndicator) fileIndicator.textContent = "";
+          if (filePreview) {
+              filePreview.src = '';
+              filePreview.style.display = 'none';
+          }
+          if (removeIcon) {
+              removeIcon.style.display = 'none';
+          }
       } catch (err) {
           loadingMsg.remove();
           const errorMsg = document.createElement('div');
@@ -157,6 +166,13 @@ async function sendMessage() {
           fileInput.value = "";
           const fileIndicator = document.getElementById('file-indicator');
           if (fileIndicator) fileIndicator.textContent = "";
+          if (filePreview) {
+              filePreview.src = '';
+              filePreview.style.display = 'none';
+          }
+          if (removeIcon) {
+              removeIcon.style.display = 'none';
+          }
       }
 }
 
@@ -166,6 +182,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const fileInput = document.getElementById("file-input");
     const fileIndicator = document.getElementById('file-indicator');
+    const filePreview = document.getElementById('file-preview');
+    const removeIcon = document.getElementById('remove-file');
 
     input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") {
@@ -177,9 +195,29 @@ document.addEventListener("DOMContentLoaded", () => {
     sendBtn.addEventListener("click", sendMessage);
     fileInput.addEventListener('change', () => {
         if (fileInput.files.length > 0) {
+            const file = fileInput.files[0];
             fileIndicator.textContent = `${fileInput.files.length} file selected`;
+            if (file && file.type.startsWith('image/')) {
+                filePreview.src = URL.createObjectURL(file);
+                filePreview.style.display = 'block';
+            } else {
+                filePreview.src = '';
+                filePreview.style.display = 'none';
+            }
+            removeIcon.style.display = 'inline';
         } else {
             fileIndicator.textContent = '';
+            filePreview.src = '';
+            filePreview.style.display = 'none';
+            removeIcon.style.display = 'none';
         }
+    });
+
+    removeIcon.addEventListener('click', () => {
+        fileInput.value = '';
+        fileIndicator.textContent = '';
+        filePreview.src = '';
+        filePreview.style.display = 'none';
+        removeIcon.style.display = 'none';
     });
 });

--- a/style.css
+++ b/style.css
@@ -59,6 +59,18 @@ input[type="text"] {
   color: #555;
 }
 
+.file-preview {
+  max-height: 40px;
+  display: none;
+}
+
+.remove-icon {
+  cursor: pointer;
+  display: none;
+  margin-left: 4px;
+  font-size: 16px;
+}
+
 #send-btn {
   background-color: #c55982;
   border: none;


### PR DESCRIPTION
## Summary
- show file preview and remove icon beside the file input
- clear preview, indicator, and input when a file is removed or cancelled
- reset preview and indicator after sending a message

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acccce0904832dad83c923f4fc4e55