### PR TITLE
Track image prompt history for image edits

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
-let lastPromptWasImage = false;
-let lastImagePrompt = "";
+let imagePromptHistory = [];
 let lastThreadId = null;
 let lastImageUrl = "";
 
@@ -104,7 +103,7 @@ async function sendMessage() {
         const payload = {
             message,
             threadId: getOrCreateThreadId(),
-            lastImagePrompt,
+            promptHistory: imagePromptHistory,
             lastImageUrl
         };
 
@@ -157,8 +156,12 @@ async function sendMessage() {
             lastImageUrl = data.imageUrl;
         }
 
-        if (data.imageUrl && isImagePrompt(message)) {
-            lastImagePrompt = message;
+        if (data.imageUrl) {
+            if (isImagePrompt(message)) {
+                imagePromptHistory = [message];
+            } else if (imagePromptHistory.length > 0) {
+                imagePromptHistory.push(message);
+            }
         }
     } catch (err) {
         const errorMsg = document.createElement('div');

--- a/tests/isImageRequest.test.js
+++ b/tests/isImageRequest.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 const { isImageRequest } = require('../functions/assistant');
 
-assert.strictEqual(isImageRequest('draw a cat'), true, 'direct image prompt');
-assert.strictEqual(isImageRequest('Make it blue', 'draw a cat'), true, 'edit with reference to previous prompt');
-assert.strictEqual(isImageRequest('How are you?'), false, 'non-image prompt');
-assert.strictEqual(isImageRequest('Make the phone a little smaller', 'draw a phone'), true, 'edit without image keyword');
+assert.strictEqual(isImageRequest('draw a cat', []), true, 'direct image prompt');
+assert.strictEqual(isImageRequest('Make it blue', ['draw a cat']), true, 'edit with reference to previous prompt');
+assert.strictEqual(isImageRequest('How are you?', []), false, 'non-image prompt');
+assert.strictEqual(isImageRequest('Make the phone a little smaller', ['draw a phone']), true, 'edit without image keyword');
 
 console.log('All isImageRequest tests passed.');


### PR DESCRIPTION
## Summary
- track array of image prompts in the browser and send it to the backend
- update assistant function to accept prompt history and combine it for edits
- adapt tests for new prompt history API

## Testing
- `node tests/isImageRequest.test.js`
- `node --check script.js`
- `node --check functions/assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0519842b8832d8f498d05aa109988