### PR TITLE
Handle base64 images for edit flow

### DIFF
--- a/functions/assistant.js
+++ b/functions/assistant.js
@@ -37,6 +37,7 @@ exports.handler = async (event) => {
             threadId,
             promptHistory = [],
             lastImageUrl,
+            lastImageBase64,
             attachment,
             attachmentName,
             attachmentType
@@ -262,6 +263,8 @@ exports.handler = async (event) => {
                 const images = [];
                 if (attachment) {
                     images.push({ name: attachmentName || 'upload', data: attachment });
+                } else if (lastImageBase64) {
+                    images.push({ name: 'previous.png', data: lastImageBase64 });
                 } else if (lastImageUrl) {
                     try {
                         const prevRes = await fetch(lastImageUrl);


### PR DESCRIPTION
## Summary
- store base64 of generated images client-side and include in payloads
- use provided base64 in assistant fallback image edits

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0791ab20c832d83cb87b7561573f0