### PR TITLE
feat: share image request detector

### DIFF
--- a/functions/assistant.js
+++ b/functions/assistant.js
@@ -1,10 +1,4 @@
-function isImageRequest(prompt, promptHistory = []) {
-    const directImagePrompt = /draw|illustrate|image|picture|generate.*image|create.*image/i.test(prompt);
-    const editRequest = /(make|change|remove|replace|update|edit)(.*image|.*it|)/i.test(prompt);
-    return directImagePrompt || (promptHistory.length > 0 && editRequest);
-}
-
-exports.isImageRequest = isImageRequest;
+const { isImageRequest } = require('../image-request');
 
 function enhancePrompt(prompt) {
     return `In a cute, cartoon, craft-friendly style: ${prompt}`;

--- a/image-request.js
+++ b/image-request.js
@@ -1,0 +1,29 @@
+function detectImageRequest(prompt, promptHistory = []) {
+    const lower = (prompt || "").toLowerCase();
+    const directKeywords = [
+        "draw",
+        "sketch",
+        "illustrate",
+        "render",
+        "create an image",
+        "generate an image",
+        "show me",
+        "picture of",
+        "image of"
+    ];
+    const direct = directKeywords.some(kw => lower.includes(kw));
+    const editKeywords = ["make", "change", "remove", "replace", "update", "edit"];
+    const edit = promptHistory.length > 0 && editKeywords.some(kw => lower.includes(kw));
+    return { isImageRequest: direct || edit, isDirect: direct, isEdit: edit };
+}
+
+function isImageRequest(prompt, promptHistory = []) {
+    return detectImageRequest(prompt, promptHistory).isImageRequest;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { detectImageRequest, isImageRequest };
+} else {
+    window.detectImageRequest = detectImageRequest;
+    window.isImageRequest = isImageRequest;
+}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             </div>
         </footer>
     </div>
+    <script src="image-request.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -16,10 +16,6 @@ function storeThreadId(id) {
     sessionStorage.setItem('mgl_thread_id', id);
 }
 
-function isImagePrompt(msg) {
-    const imageKeywords = ["draw", "sketch", "illustrate", "render", "create an image", "generate an image", "show me", "picture of", "image of"];
-    return imageKeywords.some(kw => msg.toLowerCase().includes(kw));
-}
 
 function readFileAsBase64(file) {
     return new Promise((resolve, reject) => {
@@ -179,9 +175,10 @@ async function sendMessage() {
         }
 
         if (data.imageUrl) {
-            if (isImagePrompt(message)) {
+            const { isDirect, isEdit } = detectImageRequest(message, imagePromptHistory);
+            if (isDirect) {
                 imagePromptHistory = [message];
-            } else if (imagePromptHistory.length > 0) {
+            } else if (isEdit || imagePromptHistory.length > 0) {
                 imagePromptHistory.push(message);
             }
         }

--- a/tests/isImageRequest.test.js
+++ b/tests/isImageRequest.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { isImageRequest } = require('../functions/assistant');
+const { isImageRequest } = require('../image-request');
 
 assert.strictEqual(isImageRequest('draw a cat', []), true, 'direct image prompt');
 assert.strictEqual(isImageRequest('Make it blue', ['draw a cat']), true, 'edit with reference to previous prompt');


### PR DESCRIPTION
## Summary
- add shared `isImageRequest`/`detectImageRequest` utility
- use detector in web client and assistant function for consistent image generation/editing
- include shared detector in browser and update tests

## Testing
- `node tests/isImageRequest.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b079cc1bd8832db2c2df7c25fc268f