### PR TITLE
Use arrayBuffer for image fetch

### DIFF
--- a/functions/assistant.js
+++ b/functions/assistant.js
@@ -337,7 +337,7 @@ exports.handler = async (event) => {
                     body: JSON.stringify({ error: 'Failed to fetch image content' })
                 };
             }
-            const buffer = await imageResp.buffer();
+            const buffer = await imageResp.arrayBuffer();
             const base64Image = Buffer.from(buffer).toString('base64');
             assistantResponse.image = `data:image/png;base64,${base64Image}`;
         }


### PR DESCRIPTION
## Summary
- Use `arrayBuffer()` when downloading image content so it works with the standard Fetch API.

## Testing
- ⚠️ `npm test` (fails: Missing script "test")
- ✅ `node tests/isImageRequest.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b07f2a1004832da4227a80b7ee7c02