### PR TITLE
feat: include error details in assistant message

### DIFF
--- a/functions/assistant.js
+++ b/functions/assistant.js
@@ -168,11 +168,11 @@ exports.handler = async (event) => {
         });
         if (!msgResp.ok) {
             const errText = await msgResp.text();
-            console.error('Failed to post message:', errText);
+            console.error(`Failed to post message (status ${msgResp.status}):`, errText);
             return {
                 statusCode: msgResp.status,
                 headers,
-                body: JSON.stringify({ error: 'Failed to post message to thread' })
+                body: JSON.stringify({ error: errText })
             };
         }
 


### PR DESCRIPTION
## Summary
- expose upstream error details when posting messages to OpenAI threads

## Testing
- `node tests/isImageRequest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09fc736a8832dbbe68031403cf24e